### PR TITLE
Fix TTS announcements pausing (and killing) background music

### DIFF
--- a/app/src/main/kotlin/com/hackerapps/c2k/engine/tts/TtsManager.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/engine/tts/TtsManager.kt
@@ -21,6 +21,7 @@ class TtsManager(
 
     companion object {
         val isAvailableOnDevice = MutableStateFlow<Boolean?>(null)
+        private const val TAG = "TtsManager"
     }
 
     private val context: Context = context.applicationContext
@@ -29,13 +30,45 @@ class TtsManager(
     private var pendingAnnouncement: TtsAnnouncement? = null
 
     private val audioManager = this.context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+
+    // USAGE_ASSISTANCE_NAVIGATION_GUIDANCE + CONTENT_TYPE_SPEECH is the idiomatic pairing for a
+    // short spoken cue that should DUCK music rather than pause it (the same profile a navigation
+    // app uses for turn-by-turn prompts), which the platform's ducking heuristics are tuned around.
     private val ttsAudioAttributes = AudioAttributes.Builder()
         .setUsage(AudioAttributes.USAGE_ASSISTANCE_NAVIGATION_GUIDANCE)
         .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
         .build()
-    private val focusRequest = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT)
+
+    // ROOT-CAUSE FIX: request AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK, not GAIN_TRANSIENT. On API 26+
+    // the system auto-ducks the other player for the life of our focus session and delivers it
+    // AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK (-3, "keep playing quietly") instead of the pause-inducing
+    // AUDIOFOCUS_LOSS_TRANSIENT (-2). GAIN_TRANSIENT made music players pause; a paused media
+    // service then drops its foreground state and gets killed by the OS, which is why background
+    // music "stopped and never restarted". willPauseWhenDucked=false (the default, stated for
+    // intent) means we want the other app ducked, never paused.
+    private val focusRequest = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
         .setAudioAttributes(ttsAudioAttributes)
+        .setWillPauseWhenDucked(false)
         .build()
+
+    // ---- Focus-session bookkeeping (every access guarded by focusLock) ----------------------
+    // One focus session spans a whole announcement GROUP (a QUEUE_FLUSH utterance plus any
+    // QUEUE_ADD follow-ups). Live utterances are tracked by id in `pending`; `holdsFocus` records
+    // whether we currently own a focus request. Invariants that keep this leak-free:
+    //   - Acquire only on the !holdsFocus edge, so a group requests focus at most once and a new
+    //     utterance queued mid-duck does not re-request (which could re-trigger the duck ramp).
+    //   - On QUEUE_FLUSH, clear `pending` FIRST: the previous group's queued utterances are being
+    //     cancelled, and a flushed/never-started utterance is not guaranteed to deliver a terminal
+    //     callback. Forgetting their ids up front means a late (or missing) callback for them can
+    //     neither strand the session (leak) nor be miscounted -- correctness no longer depends on
+    //     whether the engine emits onStop/onError for dropped utterances.
+    //   - Abandon exactly once, when `pending` drains to empty while we hold focus.
+    // AudioManager request/abandon are made inside the lock so the acquire / last-drain edge
+    // decision is atomic with the holdsFocus mutation, closing the acquire-after-abandon race
+    // between announce() (engine runLoop thread) and the terminal callbacks (TTS binder thread).
+    private val focusLock = Any()
+    private val pending = HashSet<String>()
+    private var holdsFocus = false
 
     override var isAvailable: Boolean = false
         private set
@@ -50,13 +83,13 @@ class TtsManager(
             tts.setAudioAttributes(ttsAudioAttributes)
             tts.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
                 override fun onStart(utteranceId: String?) {}
-                override fun onDone(utteranceId: String?) {
-                    if (!tts.isSpeaking) audioManager.abandonAudioFocusRequest(focusRequest)
-                }
+                override fun onDone(utteranceId: String?) = finishUtterance(utteranceId)
+                // Fires for utterances dropped by a later QUEUE_FLUSH or by tts.stop(); handling it
+                // together with clear-on-flush is what closes the focus leak.
+                override fun onStop(utteranceId: String?, interrupted: Boolean) = finishUtterance(utteranceId)
                 @Deprecated("Deprecated in Java")
-                override fun onError(utteranceId: String?) {
-                    audioManager.abandonAudioFocusRequest(focusRequest)
-                }
+                override fun onError(utteranceId: String?) = finishUtterance(utteranceId)
+                override fun onError(utteranceId: String?, errorCode: Int) = finishUtterance(utteranceId)
             })
             ready = true
             isAvailable = true
@@ -65,7 +98,7 @@ class TtsManager(
             pendingAnnouncement = null
         } else {
             isAvailableOnDevice.value = false
-            Log.w("TtsManager", "TextToSpeech initialization failed (status=$status)")
+            Log.w(TAG, "TextToSpeech initialization failed (status=$status)")
         }
     }
 
@@ -79,14 +112,61 @@ class TtsManager(
         val params = if (volume < 1.0f) Bundle().apply {
             putFloat(TextToSpeech.Engine.KEY_PARAM_VOLUME, volume)
         } else null
-        audioManager.requestAudioFocus(focusRequest)
-        tts.speak(text, mode, params, "c2k_${System.nanoTime()}")
+        val utteranceId = "c2k_${System.nanoTime()}"
+
+        synchronized(focusLock) {
+            // QUEUE_FLUSH discards whatever the previous group left queued; forget those ids now so
+            // a missing terminal callback for them can never strand the session (see invariants).
+            if (!queueAdd) pending.clear()
+            pending.add(utteranceId)
+
+            // Acquire only when we don't already hold focus, so a group ducks the other app once
+            // and continuously rather than re-ducking per utterance.
+            if (!holdsFocus) {
+                val res = audioManager.requestAudioFocus(focusRequest)
+                holdsFocus = res != AudioManager.AUDIOFOCUS_REQUEST_FAILED
+                if (!holdsFocus) Log.w(TAG, "Audio focus not granted (res=$res); speaking without duck")
+            }
+        }
+
+        // speak() outside the lock; its callbacks may land on a binder thread, but the id is
+        // already registered so an early onDone/onStop still balances correctly.
+        val speakResult = tts.speak(text, mode, params, utteranceId)
+        if (speakResult == TextToSpeech.ERROR) {
+            // Synchronous failure: no callback will arrive for this id, so balance it now.
+            finishUtterance(utteranceId)
+        }
+    }
+
+    // Terminal handler for every utterance (done / stopped / error), on the TTS binder thread — or
+    // on the caller thread for a synchronous speak() failure. Removes the id and, once the whole
+    // group has drained, abandons focus so the other player ramps back to full volume.
+    private fun finishUtterance(utteranceId: String?) {
+        synchronized(focusLock) {
+            if (utteranceId != null) pending.remove(utteranceId)
+            if (pending.isEmpty() && holdsFocus) {
+                audioManager.abandonAudioFocusRequest(focusRequest)
+                holdsFocus = false
+            }
+        }
+    }
+
+    // Authoritative release: unconditionally drop focus and reset accounting. Used at shutdown so
+    // the other player is never left ducked even if callbacks stop arriving.
+    private fun forceAbandon() {
+        synchronized(focusLock) {
+            pending.clear()
+            if (holdsFocus) {
+                audioManager.abandonAudioFocusRequest(focusRequest)
+                holdsFocus = false
+            }
+        }
     }
 
     override fun shutdown() {
         tts.stop()
         tts.shutdown()
-        audioManager.abandonAudioFocusRequest(focusRequest)
+        forceAbandon()
         ready = false
     }
 

--- a/app/src/main/kotlin/com/hackerapps/c2k/engine/tts/TtsManager.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/engine/tts/TtsManager.kt
@@ -30,42 +30,22 @@ class TtsManager(
     private var pendingAnnouncement: TtsAnnouncement? = null
 
     private val audioManager = this.context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-
-    // USAGE_ASSISTANCE_NAVIGATION_GUIDANCE + CONTENT_TYPE_SPEECH is the idiomatic pairing for a
-    // short spoken cue that should DUCK music rather than pause it (the same profile a navigation
-    // app uses for turn-by-turn prompts), which the platform's ducking heuristics are tuned around.
     private val ttsAudioAttributes = AudioAttributes.Builder()
         .setUsage(AudioAttributes.USAGE_ASSISTANCE_NAVIGATION_GUIDANCE)
         .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
         .build()
 
-    // ROOT-CAUSE FIX: request AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK, not GAIN_TRANSIENT. On API 26+
-    // the system auto-ducks the other player for the life of our focus session and delivers it
-    // AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK (-3, "keep playing quietly") instead of the pause-inducing
-    // AUDIOFOCUS_LOSS_TRANSIENT (-2). GAIN_TRANSIENT made music players pause; a paused media
-    // service then drops its foreground state and gets killed by the OS, which is why background
-    // music "stopped and never restarted". willPauseWhenDucked=false (the default, stated for
-    // intent) means we want the other app ducked, never paused.
+    // MAY_DUCK so the system ducks the other player rather than pausing it. GAIN_TRANSIENT sends
+    // AUDIOFOCUS_LOSS_TRANSIENT to other apps, which causes music players to pause; a paused media
+    // service then drops its foreground state and gets killed by the OS.
     private val focusRequest = AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK)
         .setAudioAttributes(ttsAudioAttributes)
-        .setWillPauseWhenDucked(false)
         .build()
 
-    // ---- Focus-session bookkeeping (every access guarded by focusLock) ----------------------
-    // One focus session spans a whole announcement GROUP (a QUEUE_FLUSH utterance plus any
-    // QUEUE_ADD follow-ups). Live utterances are tracked by id in `pending`; `holdsFocus` records
-    // whether we currently own a focus request. Invariants that keep this leak-free:
-    //   - Acquire only on the !holdsFocus edge, so a group requests focus at most once and a new
-    //     utterance queued mid-duck does not re-request (which could re-trigger the duck ramp).
-    //   - On QUEUE_FLUSH, clear `pending` FIRST: the previous group's queued utterances are being
-    //     cancelled, and a flushed/never-started utterance is not guaranteed to deliver a terminal
-    //     callback. Forgetting their ids up front means a late (or missing) callback for them can
-    //     neither strand the session (leak) nor be miscounted -- correctness no longer depends on
-    //     whether the engine emits onStop/onError for dropped utterances.
-    //   - Abandon exactly once, when `pending` drains to empty while we hold focus.
-    // AudioManager request/abandon are made inside the lock so the acquire / last-drain edge
-    // decision is atomic with the holdsFocus mutation, closing the acquire-after-abandon race
-    // between announce() (engine runLoop thread) and the terminal callbacks (TTS binder thread).
+    // Focus is held for an entire announcement group (a QUEUE_FLUSH utterance plus any QUEUE_ADD
+    // follow-ups) and released once all utterances in the group have finished or been discarded.
+    // On QUEUE_FLUSH the previous group's pending ids are cleared immediately: a flushed utterance
+    // may never deliver a terminal callback, and waiting for one would leak focus.
     private val focusLock = Any()
     private val pending = HashSet<String>()
     private var holdsFocus = false
@@ -84,8 +64,7 @@ class TtsManager(
             tts.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
                 override fun onStart(utteranceId: String?) {}
                 override fun onDone(utteranceId: String?) = finishUtterance(utteranceId)
-                // Fires for utterances dropped by a later QUEUE_FLUSH or by tts.stop(); handling it
-                // together with clear-on-flush is what closes the focus leak.
+                // onStop fires when an utterance is cancelled by tts.stop() or a later QUEUE_FLUSH
                 override fun onStop(utteranceId: String?, interrupted: Boolean) = finishUtterance(utteranceId)
                 @Deprecated("Deprecated in Java")
                 override fun onError(utteranceId: String?) = finishUtterance(utteranceId)
@@ -115,13 +94,8 @@ class TtsManager(
         val utteranceId = "c2k_${System.nanoTime()}"
 
         synchronized(focusLock) {
-            // QUEUE_FLUSH discards whatever the previous group left queued; forget those ids now so
-            // a missing terminal callback for them can never strand the session (see invariants).
             if (!queueAdd) pending.clear()
             pending.add(utteranceId)
-
-            // Acquire only when we don't already hold focus, so a group ducks the other app once
-            // and continuously rather than re-ducking per utterance.
             if (!holdsFocus) {
                 val res = audioManager.requestAudioFocus(focusRequest)
                 holdsFocus = res != AudioManager.AUDIOFOCUS_REQUEST_FAILED
@@ -129,18 +103,14 @@ class TtsManager(
             }
         }
 
-        // speak() outside the lock; its callbacks may land on a binder thread, but the id is
-        // already registered so an early onDone/onStop still balances correctly.
+        // speak() is called outside the lock; the id is already registered so an early
+        // onDone/onStop callback from the TTS binder thread still balances correctly.
         val speakResult = tts.speak(text, mode, params, utteranceId)
         if (speakResult == TextToSpeech.ERROR) {
-            // Synchronous failure: no callback will arrive for this id, so balance it now.
             finishUtterance(utteranceId)
         }
     }
 
-    // Terminal handler for every utterance (done / stopped / error), on the TTS binder thread — or
-    // on the caller thread for a synchronous speak() failure. Removes the id and, once the whole
-    // group has drained, abandons focus so the other player ramps back to full volume.
     private fun finishUtterance(utteranceId: String?) {
         synchronized(focusLock) {
             if (utteranceId != null) pending.remove(utteranceId)
@@ -151,8 +121,6 @@ class TtsManager(
         }
     }
 
-    // Authoritative release: unconditionally drop focus and reset accounting. Used at shutdown so
-    // the other player is never left ducked even if callbacks stop arriving.
     private fun forceAbandon() {
         synchronized(focusLock) {
             pending.clear()


### PR DESCRIPTION
## Problem

Pace-change TTS cues stopped the user's music/audiobook instead of playing over it. Most runners play music or an audiobook while running, so an announcement must duck the audio briefly, never pause it.

Per on-device `dumpsys audio`, the cause was requesting `AUDIOFOCUS_GAIN_TRANSIENT` (`req=2`): the active media app receives `AUDIOFOCUS_LOSS_TRANSIENT` (`-2`) and pauses. A *paused* background media service then drops its foreground state and is killed by the OS, so it never resumes. The behavior was unpredictable and worse with the screen off (Doze reaps the paused service).

## Fix

- Request `AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK` (`req=3`) so on API 26+ (minSdk is 26) the system auto-ducks the other player and never sends it a pause.
- Rework the focus lifecycle: track in-flight utterances by id and clear the set on `QUEUE_FLUSH`, so focus is released exactly once per announcement group and cannot leak (a leak would leave the other app stuck ducked) across the `FLUSH + QUEUE_ADD` cue groups the workout engine emits. Focus request/abandon happen inside the lock to close an acquire-after-abandon race between the engine thread and the TTS binder-thread callbacks.

## Verification

- `./gradlew :app:compileFossDebugKotlin` and `:app:testFossDebugUnitTest` pass.
- On device (OnePlus 7T), `dumpsys audio` now shows the other player ducking `1.0 -> 0.2` and staying `state:started`, then un-ducking after `abandonAudioFocus` — instead of the previous `-2 / handleLoss -> died`.

## Scope

One file (`TtsManager.kt`), no new dependencies, no new permissions; the app remains fully offline.
