### PR TITLE
Fix workout counter frozen at 1-3s when screen locked at completion

### DIFF
--- a/app/src/main/kotlin/com/hackerapps/c2k/engine/WorkoutEngine.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/engine/WorkoutEngine.kt
@@ -98,6 +98,19 @@ class WorkoutEngine(
             if (remaining <= 0) {
                 intervalIndex++
                 if (intervalIndex >= intervals.size) {
+                    // Pin a final Active frame to 0 before completing. When the screen is locked
+                    // the UI's lifecycle-aware collector is suspended and freezes on the last
+                    // Active value it received; without this it stays showing 1-3s left (the last
+                    // tick before the boundary) even though the workout is already done.
+                    _state.value = WorkoutState.Active(
+                        currentInterval = currentInterval,
+                        nextInterval = null,
+                        intervalIndex = intervalIndex - 1,
+                        totalIntervals = intervals.size,
+                        secondsRemainingInInterval = 0,
+                        elapsedSessionSeconds = sessionElapsed,
+                        sessionId = sessionId
+                    )
                     if (ttsEnabled) tts.announce(TtsAnnouncement.WorkoutComplete)
                     _state.value = WorkoutState.Completed(sessionId, sessionElapsed)
                     tickJob?.cancel()

--- a/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/workout/WorkoutViewModel.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/workout/WorkoutViewModel.kt
@@ -84,6 +84,12 @@ class WorkoutViewModel(app: Application) : AndroidViewModel(app) {
             }
             viewModelScope.launch {
                 lb.getWorkoutState().collect { state ->
+                    // Latch the terminal state: once completed, ignore any late/stale Active or
+                    // Idle frame (e.g. a fresh Idle service auto-created by a rebind after the
+                    // foreground service self-stops) so the UI can't revert to a live counter.
+                    if (_workoutState.value is WorkoutState.Completed && state !is WorkoutState.Completed) {
+                        return@collect
+                    }
                     _workoutState.value = state
                     if (state is WorkoutState.Completed && currentProgramId.isNotEmpty()) {
                         loadPersonalBest()


### PR DESCRIPTION
Fixes the workout counter freezing at 1–3s when the screen is locked as the cool-down ends: the engine now emits a final `0:00` frame before completing, and the VM latches the terminal state.

Low-effort drive-by suggestion — no real effort put in, just tested on my own device (OnePlus 7T). Zero pressure to keep it; close it if it's not a fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
