### PR TITLE
Add manually marking a workout day done / not done

### DIFF
--- a/app/schemas/com.hackerapps.c2k.data.db.AppDatabase/2.json
+++ b/app/schemas/com.hackerapps.c2k.data.db.AppDatabase/2.json
@@ -1,0 +1,161 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "fbf71b583d02827dec49746066de51c3",
+    "entities": [
+      {
+        "tableName": "workout_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `programId` TEXT NOT NULL, `week` INTEGER NOT NULL, `day` INTEGER NOT NULL, `startedAt` INTEGER NOT NULL, `completedAt` INTEGER, `durationSeconds` INTEGER NOT NULL, `distanceMeters` REAL NOT NULL, `completed` INTEGER NOT NULL, `manual` INTEGER NOT NULL DEFAULT 0)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "programId",
+            "columnName": "programId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "week",
+            "columnName": "week",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "day",
+            "columnName": "day",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startedAt",
+            "columnName": "startedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completedAt",
+            "columnName": "completedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "durationSeconds",
+            "columnName": "durationSeconds",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "distanceMeters",
+            "columnName": "distanceMeters",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "manual",
+            "columnName": "manual",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "route_points",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` INTEGER NOT NULL, `latitude` REAL NOT NULL, `longitude` REAL NOT NULL, `altitudeMeters` REAL, `speedMps` REAL, `recordedAt` INTEGER NOT NULL, FOREIGN KEY(`sessionId`) REFERENCES `workout_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "latitude",
+            "columnName": "latitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "longitude",
+            "columnName": "longitude",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "altitudeMeters",
+            "columnName": "altitudeMeters",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "speedMps",
+            "columnName": "speedMps",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "recordedAt",
+            "columnName": "recordedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_route_points_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_route_points_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "workout_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'fbf71b583d02827dec49746066de51c3')"
+    ]
+  }
+}

--- a/app/src/main/kotlin/com/hackerapps/c2k/data/db/AppDatabase.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/data/db/AppDatabase.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.hackerapps.c2k.data.db.dao.RoutePointDao
 import com.hackerapps.c2k.data.db.dao.WorkoutSessionDao
 import com.hackerapps.c2k.data.db.entity.RoutePointEntity
@@ -11,7 +13,7 @@ import com.hackerapps.c2k.data.db.entity.WorkoutSessionEntity
 
 @Database(
     entities = [WorkoutSessionEntity::class, RoutePointEntity::class],
-    version = 1,
+    version = 2,
     exportSchema = true
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -20,8 +22,19 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun routePointDao(): RoutePointDao
 
     companion object {
+        // Adds the `manual` flag for manually-marked days. A real migration (rather than the
+        // destructive fallback) so existing run history survives the upgrade.
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE workout_sessions ADD COLUMN manual INTEGER NOT NULL DEFAULT 0")
+            }
+        }
+
         fun create(context: Context): AppDatabase =
             Room.databaseBuilder(context, AppDatabase::class.java, "c2k.db")
+                .addMigrations(MIGRATION_1_2)
+                // Backstop for any unhandled future version jump; the 1->2 path above is used
+                // for the current upgrade so history is preserved.
                 .fallbackToDestructiveMigration(dropAllTables = true)
                 .build()
     }

--- a/app/src/main/kotlin/com/hackerapps/c2k/data/db/dao/WorkoutSessionDao.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/data/db/dao/WorkoutSessionDao.kt
@@ -25,9 +25,14 @@ interface WorkoutSessionDao {
     @Query("SELECT DISTINCT week, day FROM workout_sessions WHERE programId = :programId AND completed = 1")
     fun observeCompletedDays(programId: String): Flow<List<CompletedDay>>
 
+    // Days completed only by a manual mark (used to offer "mark as not done").
+    @Query("SELECT DISTINCT week, day FROM workout_sessions WHERE programId = :programId AND completed = 1 AND manual = 1")
+    fun observeManualDays(programId: String): Flow<List<CompletedDay>>
+
+    // Personal best excludes manual marks — they have no real duration (0s would always win).
     @Query("""
         SELECT * FROM workout_sessions
-        WHERE programId = :programId AND week = :week AND day = :day AND completed = 1
+        WHERE programId = :programId AND week = :week AND day = :day AND completed = 1 AND manual = 0
         ORDER BY durationSeconds ASC
         LIMIT 1
     """)
@@ -41,6 +46,10 @@ interface WorkoutSessionDao {
 
     @Query("DELETE FROM workout_sessions WHERE id = :id")
     suspend fun deleteById(id: Long)
+
+    // Remove only manual marks for a day — never deletes a real completed run.
+    @Query("DELETE FROM workout_sessions WHERE programId = :programId AND week = :week AND day = :day AND manual = 1")
+    suspend fun deleteManualByDay(programId: String, week: Int, day: Int)
 
     @Query("DELETE FROM workout_sessions WHERE programId = :programId")
     suspend fun deleteByProgramId(programId: String)

--- a/app/src/main/kotlin/com/hackerapps/c2k/data/db/entity/WorkoutSessionEntity.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/data/db/entity/WorkoutSessionEntity.kt
@@ -1,5 +1,6 @@
 package com.hackerapps.c2k.data.db.entity
 
+import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
@@ -13,5 +14,10 @@ data class WorkoutSessionEntity(
     val completedAt: Long? = null,
     val durationSeconds: Int,
     val distanceMeters: Float,
-    val completed: Boolean
+    val completed: Boolean,
+    // True for a day the user manually marked done (not an actual run). Counts toward program
+    // progress and streak like a real day, but is excluded from personal-best and distance/time
+    // stats (it has no duration/distance). defaultValue keeps the entity schema in sync with the
+    // v1->2 migration's ADD COLUMN ... DEFAULT 0.
+    @ColumnInfo(defaultValue = "0") val manual: Boolean = false
 )

--- a/app/src/main/kotlin/com/hackerapps/c2k/data/repository/SessionRepository.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/data/repository/SessionRepository.kt
@@ -57,6 +57,33 @@ class SessionRepository(private val db: AppDatabase) {
         db.sessionDao().observeCompletedDays(programId)
             .map { list -> list.map { it.week to it.day }.toSet() }
 
+    fun observeManualDays(programId: String): Flow<Set<Pair<Int, Int>>> =
+        db.sessionDao().observeManualDays(programId)
+            .map { list -> list.map { it.week to it.day }.toSet() }
+
+    // Marks a day complete without an actual run (counts toward progress/streak; zero duration
+    // and distance so it stays out of personal-best and distance/time stats).
+    suspend fun markDayDone(programId: String, week: Int, day: Int) {
+        val now = System.currentTimeMillis()
+        db.sessionDao().insert(
+            WorkoutSessionEntity(
+                programId = programId,
+                week = week,
+                day = day,
+                startedAt = now,
+                completedAt = now,
+                durationSeconds = 0,
+                distanceMeters = 0f,
+                completed = true,
+                manual = true
+            )
+        )
+    }
+
+    // Removes only manual marks for a day; a real completed run for that day is left intact.
+    suspend fun unmarkDay(programId: String, week: Int, day: Int) =
+        db.sessionDao().deleteManualByDay(programId, week, day)
+
     suspend fun getBestForDay(programId: String, week: Int, day: Int): WorkoutSessionEntity? =
         db.sessionDao().getBestByDay(programId, week, day)
 

--- a/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/history/HistoryViewModel.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/history/HistoryViewModel.kt
@@ -26,7 +26,10 @@ class HistoryViewModel(app: Application) : AndroidViewModel(app) {
 
     private val repo = (app as C2KApp).sessionRepository
 
+    // History lists actual runs only; manually-marked days (which have no duration/distance)
+    // are filtered out so they don't appear as 0:00 entries or skew the km/time stats.
     val sessions: StateFlow<List<WorkoutSessionEntity>> = repo.observeAllSessions()
+        .map { list -> list.filter { !it.manual } }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), emptyList())
 
     val stats: StateFlow<HistoryStats> = sessions.map { list -> computeStats(list) }

--- a/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/home/HomeViewModel.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/home/HomeViewModel.kt
@@ -60,7 +60,8 @@ class HomeViewModel(app: Application) : AndroidViewModel(app) {
         nextWorkoutFlow
     ) { allSessions, active, workoutInfo, nextWorkout ->
         HomeUiState(
-            recentSessions = allSessions.take(5),
+            // Recent list shows real runs only; streak still counts manually-marked days.
+            recentSessions = allSessions.filter { !it.manual }.take(5),
             streak = computeStreak(allSessions, System.currentTimeMillis()),
             workoutActive = active,
             activeWorkoutInfo = workoutInfo,

--- a/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/program/ProgramSelectScreen.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/program/ProgramSelectScreen.kt
@@ -113,6 +113,15 @@ fun ProgramSelectScreen(
             onStart = {
                 previewDay = null
                 onStartWorkout(previewWeek, previewDayNum)
+            },
+            isManual = (previewWeek to previewDayNum) in state.manualDays,
+            onMarkDone = {
+                vm.markDayDone(previewWeek, previewDayNum)
+                previewDay = null
+            },
+            onUnmark = {
+                vm.unmarkDay(previewWeek, previewDayNum)
+                previewDay = null
             }
         )
     }

--- a/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/program/ProgramSelectViewModel.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/program/ProgramSelectViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import com.hackerapps.c2k.C2KApp
 import com.hackerapps.c2k.data.model.Programs
@@ -15,7 +15,9 @@ import com.hackerapps.c2k.data.model.WorkoutPlan
 
 data class ProgramSelectUiState(
     val plan: WorkoutPlan? = null,
-    val completedDays: Set<Pair<Int, Int>> = emptySet()
+    val completedDays: Set<Pair<Int, Int>> = emptySet(),
+    // Subset of completedDays whose completion came only from a manual mark (offer "un-mark").
+    val manualDays: Set<Pair<Int, Int>> = emptySet()
 ) {
     val nextIncompleteDay: Pair<Int, Int>? get() {
         val p = plan ?: return null
@@ -39,13 +41,24 @@ class ProgramSelectViewModel(
     private val repo = (app as C2KApp).sessionRepository
 
     val uiState: StateFlow<ProgramSelectUiState> =
-        repo.observeCompletedDays(programId)
-            .map { completed -> ProgramSelectUiState(plan = plan, completedDays = completed) }
-            .stateIn(
-                viewModelScope,
-                SharingStarted.WhileSubscribed(5_000),
-                ProgramSelectUiState(plan = plan)
-            )
+        combine(
+            repo.observeCompletedDays(programId),
+            repo.observeManualDays(programId)
+        ) { completed, manual ->
+            ProgramSelectUiState(plan = plan, completedDays = completed, manualDays = manual)
+        }.stateIn(
+            viewModelScope,
+            SharingStarted.WhileSubscribed(5_000),
+            ProgramSelectUiState(plan = plan)
+        )
+
+    fun markDayDone(week: Int, day: Int) {
+        viewModelScope.launch { repo.markDayDone(programId, week, day) }
+    }
+
+    fun unmarkDay(week: Int, day: Int) {
+        viewModelScope.launch { repo.unmarkDay(programId, week, day) }
+    }
 
     fun resetProgress() {
         viewModelScope.launch { repo.resetProgress(programId) }

--- a/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/program/WorkoutPreviewSheet.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/program/WorkoutPreviewSheet.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -60,7 +61,12 @@ fun WorkoutPreviewSheet(
     workoutDay: WorkoutDay,
     isCompleted: Boolean,
     onDismiss: () -> Unit,
-    onStart: () -> Unit
+    onStart: () -> Unit,
+    // Optional manual mark-as-done controls. When null (e.g. the Home "continue" shortcut) no
+    // mark button is shown. isManual = the day's completion came from a manual mark (offer un-mark).
+    isManual: Boolean = false,
+    onMarkDone: (() -> Unit)? = null,
+    onUnmark: (() -> Unit)? = null
 ) {
     ModalBottomSheet(onDismissRequest = onDismiss) {
         Column(
@@ -95,6 +101,15 @@ fun WorkoutPreviewSheet(
                     if (isCompleted) stringResource(R.string.program_preview_redo)
                     else stringResource(R.string.program_preview_start)
                 )
+            }
+            if (!isCompleted && onMarkDone != null) {
+                TextButton(onClick = onMarkDone, modifier = Modifier.fillMaxWidth()) {
+                    Text(stringResource(R.string.program_mark_done))
+                }
+            } else if (isCompleted && isManual && onUnmark != null) {
+                TextButton(onClick = onUnmark, modifier = Modifier.fillMaxWidth()) {
+                    Text(stringResource(R.string.program_mark_not_done))
+                }
             }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,8 @@
     <string name="program_preview_start">Start</string>
     <string name="program_preview_redo">Redo</string>
     <string name="program_preview_duration">~%1$d min</string>
+    <string name="program_mark_done">Mark as done</string>
+    <string name="program_mark_not_done">Mark as not done</string>
     <string name="program_reset_title">Reset progress</string>
     <string name="program_reset_message">This will permanently remove all completed sessions for this program. Your overall history is kept.</string>
     <string name="program_reset_confirm">Reset</string>


### PR DESCRIPTION
Mark a day done (or un-mark) without running it. Adds a `manual` column via a real Room 1→2 migration; counts toward progress/streak but is kept out of personal-best and distance/time stats.

Low-effort drive-by suggestion — no real effort put in, just tested on my own device (OnePlus 7T). Zero pressure to keep it; close it if it's not a fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
