### PR TITLE
Let the user leave the active workout without stopping it

### DIFF
--- a/app/src/main/kotlin/com/hackerapps/c2k/ui/navigation/NavGraph.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/ui/navigation/NavGraph.kt
@@ -73,7 +73,11 @@ fun NavGraph() {
                 programId = args.getString("programId")!!,
                 week      = args.getInt("week"),
                 day       = args.getInt("day"),
-                onFinished = { navController.popBackStack(Routes.HOME, inclusive = false) }
+                onFinished = { navController.popBackStack(Routes.HOME, inclusive = false) },
+                // Minimize leaves the workout running in the service and returns to Home, where the
+                // "workout in progress" banner navigates back into it.
+                onMinimize = { navController.popBackStack(Routes.HOME, inclusive = false) },
+                onOpenSettings = { navController.navigate(Routes.SETTINGS) }
             )
         }
 

--- a/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/workout/WorkoutScreen.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/workout/WorkoutScreen.kt
@@ -19,14 +19,19 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Pause
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Stop
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -56,6 +61,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.hackerapps.c2k.R
 import com.hackerapps.c2k.data.db.entity.WorkoutSessionEntity
 import com.hackerapps.c2k.data.model.IntervalType
+import com.hackerapps.c2k.data.model.Programs
 import com.hackerapps.c2k.engine.WorkoutState
 import com.hackerapps.c2k.service.WorkoutService
 import com.hackerapps.c2k.ui.component.RequestActivityRecognitionPermission
@@ -74,6 +80,8 @@ fun WorkoutScreen(
     week: Int,
     day: Int,
     onFinished: () -> Unit,
+    onMinimize: () -> Unit,
+    onOpenSettings: () -> Unit,
     vm: WorkoutViewModel = viewModel()
 ) {
     val context = LocalContext.current
@@ -95,6 +103,10 @@ fun WorkoutScreen(
     // In treadmill mode skip the location permission request entirely
     var permissionResolved by remember(treadmillMode) { mutableStateOf(treadmillMode) }
     var showStopDialog by remember { mutableStateOf(false) }
+    var showStepsSheet by remember { mutableStateOf(false) }
+    val workoutDay = remember(programId, week, day) {
+        Programs.byId(programId).weeks.getOrNull(week - 1)?.getOrNull(day - 1)
+    }
 
     val nameResId = remember(programId) { programNameRes(programId) }
     val programName = nameResId?.let { stringResource(it) } ?: programId
@@ -112,8 +124,10 @@ fun WorkoutScreen(
     }
 
     BackHandler {
+        // Back minimizes to Home while the workout keeps running in the service (return via the
+        // "workout in progress" banner). Stopping is an explicit action via the Stop button.
         if (workoutState is WorkoutState.Completed) onFinished()
-        else showStopDialog = true
+        else onMinimize()
     }
 
     DisposableEffect(keepScreenOn) {
@@ -168,11 +182,48 @@ fun WorkoutScreen(
         )
     }
 
+    if (showStepsSheet && workoutDay != null) {
+        WorkoutStepsSheet(
+            week = week,
+            day = day,
+            workoutDay = workoutDay,
+            onDismiss = { showStepsSheet = false }
+        )
+    }
+
     Scaffold(
         topBar = {
-            TopAppBar(title = {
-                Text(stringResource(R.string.workout_title, programName, stringResource(R.string.history_week_day, week, day)))
-            })
+            TopAppBar(
+                title = {
+                    Text(stringResource(R.string.workout_title, programName, stringResource(R.string.history_week_day, week, day)))
+                },
+                navigationIcon = {
+                    IconButton(onClick = onMinimize) {
+                        Icon(
+                            Icons.Default.KeyboardArrowDown,
+                            contentDescription = stringResource(R.string.workout_minimize)
+                        )
+                    }
+                },
+                actions = {
+                    var showMenu by remember { mutableStateOf(false) }
+                    IconButton(onClick = { showMenu = true }) {
+                        Icon(Icons.Default.MoreVert, contentDescription = stringResource(R.string.workout_more))
+                    }
+                    DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
+                        if (workoutDay != null) {
+                            DropdownMenuItem(
+                                text = { Text(stringResource(R.string.workout_view_steps)) },
+                                onClick = { showMenu = false; showStepsSheet = true }
+                            )
+                        }
+                        DropdownMenuItem(
+                            text = { Text(stringResource(R.string.settings_title)) },
+                            onClick = { showMenu = false; onOpenSettings() }
+                        )
+                    }
+                }
+            )
         }
     ) { padding ->
         val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE

--- a/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/workout/WorkoutStepsSheet.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/workout/WorkoutStepsSheet.kt
@@ -1,0 +1,128 @@
+package com.hackerapps.c2k.ui.screen.workout
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import com.hackerapps.c2k.R
+import com.hackerapps.c2k.data.model.Interval
+import com.hackerapps.c2k.data.model.IntervalType
+import com.hackerapps.c2k.data.model.WorkoutDay
+import com.hackerapps.c2k.ui.theme.RunOrange
+import com.hackerapps.c2k.ui.theme.WalkBlue
+import com.hackerapps.c2k.ui.theme.WarmCoolGreen
+
+// A read-only bottom sheet showing the current jog's interval breakdown, reachable from the
+// workout toolbar so the runner can review the steps without leaving (and stopping) the workout.
+// Kept self-contained (its own grouping) so this feature doesn't touch the program-screen preview.
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun WorkoutStepsSheet(
+    week: Int,
+    day: Int,
+    workoutDay: WorkoutDay,
+    onDismiss: () -> Unit
+) {
+    ModalBottomSheet(onDismissRequest = onDismiss) {
+        Column(
+            modifier = Modifier
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp)
+        ) {
+            Text(
+                stringResource(R.string.workout_steps_title, week, day),
+                style = MaterialTheme.typography.titleLarge
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                stringResource(R.string.program_preview_duration, workoutDay.totalDurationSeconds / 60),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.7f)
+            )
+            Spacer(Modifier.height(16.dp))
+            HorizontalDivider()
+            Spacer(Modifier.height(8.dp))
+
+            LazyColumn(modifier = Modifier.weight(1f, fill = false)) {
+                items(workoutDay.intervals.grouped()) { group ->
+                    StepRow(group)
+                }
+            }
+        }
+    }
+}
+
+private data class StepGroup(
+    val type: IntervalType,
+    val durationSeconds: Int,
+    val count: Int
+)
+
+private fun List<Interval>.grouped(): List<StepGroup> {
+    if (isEmpty()) return emptyList()
+    val result = mutableListOf<StepGroup>()
+    var type = first().type
+    var duration = first().durationSeconds
+    var count = 1
+    for (i in 1 until size) {
+        val iv = this[i]
+        if (iv.type == type && iv.durationSeconds == duration) {
+            count++
+        } else {
+            result.add(StepGroup(type, duration, count))
+            type = iv.type; duration = iv.durationSeconds; count = 1
+        }
+    }
+    result.add(StepGroup(type, duration, count))
+    return result
+}
+
+@Composable
+private fun StepRow(group: StepGroup) {
+    val color = when (group.type) {
+        IntervalType.RUN      -> RunOrange
+        IntervalType.WALK     -> WalkBlue
+        IntervalType.WARMUP,
+        IntervalType.COOLDOWN -> WarmCoolGreen
+    }
+    val label = when (group.type) {
+        IntervalType.RUN      -> stringResource(R.string.workout_interval_run)
+        IntervalType.WALK     -> stringResource(R.string.workout_interval_walk)
+        IntervalType.WARMUP   -> stringResource(R.string.workout_interval_warmup)
+        IntervalType.COOLDOWN -> stringResource(R.string.workout_interval_cooldown)
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 6.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        val countSuffix = if (group.count > 1) " × ${group.count}" else ""
+        Text(label + countSuffix, color = color, style = MaterialTheme.typography.bodyLarge)
+        Text(formatStepDuration(group.durationSeconds), style = MaterialTheme.typography.bodyLarge)
+    }
+}
+
+private fun formatStepDuration(seconds: Int): String {
+    val m = seconds / 60
+    val s = seconds % 60
+    return when {
+        m > 0 && s > 0 -> "${m}m ${s}s"
+        m > 0 -> "${m} min"
+        else -> "${s}s"
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,10 @@
     <string name="workout_starting">Starting…</string>
     <string name="workout_new_best">New personal best!</string>
     <string name="workout_previous_best">Previous best: %1$s</string>
+    <string name="workout_minimize">Minimize</string>
+    <string name="workout_more">More</string>
+    <string name="workout_view_steps">View steps</string>
+    <string name="workout_steps_title">Week %1$d, Day %2$d</string>
 
     <!-- History screen -->
     <string name="history_title">History</string>


### PR DESCRIPTION
Back now minimizes to Home (workout keeps running) instead of forcing the stop dialog; the toolbar gains an overflow with View steps / Settings.

Low-effort drive-by suggestion — no real effort put in, just tested on my own device (OnePlus 7T). Zero pressure to keep it; close it if it's not a fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
