### PR TITLE
feat: add manual language selection in settings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,3 +28,4 @@ See the [README](README.md) for build requirements and instructions.
 | [andrewfarabee](https://github.com/andrewfarabee) | Fix: TTS announcements duck background music instead of pausing it; Fix: completion counter freeze and cut-off completion announcement |
 | [ilyushenok](https://github.com/ilyushenok) | Russian (ru) translation |
 | [ahmetemrew](https://github.com/ahmetemrew) | Turkish (tr) translation |
+| [Unibilens](https://github.com/Unibilens) | Manual language selection and locale propagation |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,6 +113,7 @@ dependencies {
     implementation(libs.compose.material3)
     implementation(libs.compose.material.icons.extended)
     implementation(libs.activity.compose)
+    implementation(libs.appcompat)
     implementation(libs.lifecycle.viewmodel.compose)
     implementation(libs.lifecycle.runtime.compose)
     implementation(libs.navigation.compose)

--- a/app/src/androidTest/kotlin/com/hackerapps/c2k/ui/screen/contributors/ContributorsScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/hackerapps/c2k/ui/screen/contributors/ContributorsScreenTest.kt
@@ -30,7 +30,7 @@ class ContributorsScreenTest {
         assertTrue(composeRule.onAllNodesWithText("xmgz").fetchSemanticsNodes().isNotEmpty())
         composeRule.onNodeWithText("Andrew Farabee").assertExists()
         composeRule.onNodeWithText("Ilyushenok Ilya").assertExists()
-        composeRule.onNodeWithText("Unibilens").assertExists()
+        assertTrue(composeRule.onAllNodesWithText("Unibilens").fetchSemanticsNodes().isNotEmpty())
     }
 
     @Test

--- a/app/src/androidTest/kotlin/com/hackerapps/c2k/ui/screen/contributors/ContributorsScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/hackerapps/c2k/ui/screen/contributors/ContributorsScreenTest.kt
@@ -30,6 +30,7 @@ class ContributorsScreenTest {
         assertTrue(composeRule.onAllNodesWithText("xmgz").fetchSemanticsNodes().isNotEmpty())
         composeRule.onNodeWithText("Andrew Farabee").assertExists()
         composeRule.onNodeWithText("Ilyushenok Ilya").assertExists()
+        composeRule.onNodeWithText("Unibilens").assertExists()
     }
 
     @Test
@@ -39,6 +40,7 @@ class ContributorsScreenTest {
         composeRule.onNodeWithText(string(R.string.contributor_translation_es)).assertExists()
         composeRule.onNodeWithText(string(R.string.contributor_fix_tts_ducking)).assertExists()
         composeRule.onNodeWithText(string(R.string.contributor_translation_ru)).assertExists()
+        composeRule.onNodeWithText(string(R.string.contributor_language_selection)).assertExists()
     }
 
     @Test

--- a/app/src/androidTest/kotlin/com/hackerapps/c2k/ui/screen/settings/SettingsScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/hackerapps/c2k/ui/screen/settings/SettingsScreenTest.kt
@@ -358,7 +358,7 @@ class SettingsScreenTest {
         setContent()
         composeRule.onNodeWithTag("toggle_gps_enabled").assertIsEnabled()
 
-        composeRule.onNodeWithTag("toggle_treadmill_mode").performClick()
+        composeRule.onNodeWithTag("toggle_treadmill_mode").performScrollTo().performClick()
 
         composeRule.waitUntilAssertion {
             composeRule.onNodeWithTag("toggle_gps_enabled").assertIsNotEnabled()

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:localeConfig="@xml/locales_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.C2K">
@@ -47,6 +48,15 @@
             android:name=".service.WorkoutService"
             android:foregroundServiceType="health|location"
             android:exported="false" />
+
+        <service
+            android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
+            android:enabled="false"
+            android:exported="false">
+            <meta-data
+                android:name="autoStoreLocales"
+                android:value="true" />
+        </service>
 
     </application>
 

--- a/app/src/main/kotlin/com/hackerapps/c2k/engine/tts/TtsManager.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/engine/tts/TtsManager.kt
@@ -10,6 +10,7 @@ import android.speech.tts.UtteranceProgressListener
 import android.util.Log
 import com.hackerapps.c2k.R
 import com.hackerapps.c2k.data.model.IntervalType
+import com.hackerapps.c2k.utils.localized
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -25,7 +26,7 @@ class TtsManager(
         private const val TAG = "TtsManager"
     }
 
-    private val context: Context = context.applicationContext
+    private val context: Context = context.applicationContext.localized()
     private val tts = TextToSpeech(this.context, this)
     private var ready = false
     private var initializationFailure: TtsDiagnosticResult? = null

--- a/app/src/main/kotlin/com/hackerapps/c2k/service/WorkoutService.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/service/WorkoutService.kt
@@ -46,8 +46,13 @@ import com.hackerapps.c2k.location.LocationUpdate
 import com.hackerapps.c2k.location.NoOpLocationProvider
 import com.hackerapps.c2k.location.toEntity
 import com.hackerapps.c2k.ui.MainActivity
+import com.hackerapps.c2k.utils.localized
 
 class WorkoutService : Service() {
+
+    override fun attachBaseContext(newBase: Context) {
+        super.attachBaseContext(newBase.localized())
+    }
 
     data class WorkoutInfo(val programId: String, val week: Int, val day: Int)
 

--- a/app/src/main/kotlin/com/hackerapps/c2k/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/ui/MainActivity.kt
@@ -2,13 +2,13 @@ package com.hackerapps.c2k.ui
 
 import android.content.pm.ActivityInfo
 import android.os.Bundle
-import androidx.activity.ComponentActivity
+import androidx.appcompat.app.AppCompatActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import com.hackerapps.c2k.ui.navigation.NavGraph
 import com.hackerapps.c2k.ui.theme.C2KTheme
 
-class MainActivity : ComponentActivity() {
+class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         // Lock portrait at runtime on phones only: a manifest screenOrientation lock

--- a/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/contributors/ContributorsScreen.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/contributors/ContributorsScreen.kt
@@ -60,6 +60,11 @@ private val contributors = listOf(
         name = "Ahmet Emre",
         github = "ahmetemrew",
         contributionRes = listOf(R.string.contributor_translation_tr)
+    ),
+    Contributor(
+        name = "Unibilens",
+        github = "Unibilens",
+        contributionRes = listOf(R.string.contributor_language_selection)
     )
 )
 

--- a/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/settings/SettingsScreen.kt
@@ -4,6 +4,7 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.provider.Settings
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -38,6 +39,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -85,10 +87,14 @@ fun SettingsScreen(
     val voiceTestState       by vm.voiceTestState.collectAsStateWithLifecycle()
     val weightKg             by vm.weightKg.collectAsStateWithLifecycle()
     val weightUnit           by vm.weightUnit.collectAsStateWithLifecycle()
+    val currentLanguageTag   by vm.currentLanguageTag.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
     DisposableEffect(vm) {
         onDispose { vm.stopVoiceTest() }
+    }
+    LaunchedEffect(Unit) {
+        vm.refreshLanguage()
     }
 
     Scaffold(
@@ -116,6 +122,11 @@ fun SettingsScreen(
                 .imePadding()
                 .verticalScroll(rememberScrollState())
         ) {
+            LanguageSetting(
+                currentTag = currentLanguageTag,
+                onTagChange = vm::setLanguage
+            )
+            HorizontalDivider()
             SettingsToggle(
                 label = stringResource(R.string.settings_tts_enabled),
                 checked = ttsEnabled,
@@ -299,6 +310,72 @@ fun SettingsScreen(
                 onWeightChange = vm::setWeightKg,
                 onUnitChange = vm::setWeightUnit
             )
+        }
+    }
+}
+
+@Composable
+private fun LanguageSetting(
+    currentTag: String,
+    onTagChange: (String) -> Unit
+) {
+    val languages = listOf(
+        "" to R.string.language_system_default,
+        "en" to R.string.language_en,
+        "de" to R.string.language_de,
+        "es" to R.string.language_es,
+        "fr" to R.string.language_fr,
+        "gl" to R.string.language_gl,
+        "pt-BR" to R.string.language_pt_br,
+        "ru" to R.string.language_ru,
+        "tr" to R.string.language_tr
+    )
+    val currentLabelRes = languages.find { it.first == currentTag }?.second
+        ?: R.string.language_system_default
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.settings_language)) },
+        trailingContent = {
+            SettingsDropdownPicker(
+                items = languages,
+                itemLabel = { stringResource(it.second) },
+                onItemSelected = { onTagChange(it.first) },
+                anchor = { onClick ->
+                    TextButton(
+                        onClick = onClick,
+                        modifier = Modifier.testTag("button_language")
+                    ) {
+                        Text(stringResource(currentLabelRes))
+                        Icon(Icons.Default.ArrowDropDown, contentDescription = null)
+                    }
+                }
+            )
+        }
+    )
+}
+
+@Composable
+private fun <T> SettingsDropdownPicker(
+    items: List<T>,
+    itemLabel: @Composable (T) -> String,
+    onItemSelected: (T) -> Unit,
+    anchor: @Composable (onClick: () -> Unit) -> Unit
+) {
+    var expanded by remember { mutableStateOf(false) }
+    Box {
+        anchor { expanded = true }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false }
+        ) {
+            items.forEach { item ->
+                DropdownMenuItem(
+                    text = { Text(itemLabel(item)) },
+                    onClick = {
+                        expanded = false
+                        onItemSelected(item)
+                    }
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/settings/SettingsViewModel.kt
@@ -1,6 +1,8 @@
 package com.hackerapps.c2k.ui.screen.settings
 
 import android.app.Application
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -33,6 +35,25 @@ class SettingsViewModel @JvmOverloads constructor(
     private val diagnosticTtsFactory: (Application, Float, Float) -> DiagnosticTts =
         { application, rate, volume -> TtsManager(application, rate, volume) }
 ) : AndroidViewModel(app) {
+
+    private val _currentLanguageTag = MutableStateFlow(
+        AppCompatDelegate.getApplicationLocales().toLanguageTags()
+    )
+    val currentLanguageTag = _currentLanguageTag.asStateFlow()
+
+    fun refreshLanguage() {
+        _currentLanguageTag.value = AppCompatDelegate.getApplicationLocales().toLanguageTags()
+    }
+
+    fun setLanguage(tag: String) {
+        val locales = if (tag.isEmpty()) {
+            LocaleListCompat.getEmptyLocaleList()
+        } else {
+            LocaleListCompat.forLanguageTags(tag)
+        }
+        AppCompatDelegate.setApplicationLocales(locales)
+        _currentLanguageTag.value = tag
+    }
 
     private val prefs = UserPreferences(app)
 

--- a/app/src/main/kotlin/com/hackerapps/c2k/utils/ContextExt.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/utils/ContextExt.kt
@@ -1,0 +1,21 @@
+package com.hackerapps.c2k.utils
+
+import android.content.Context
+import android.content.res.Configuration
+import android.os.Build
+import android.os.LocaleList
+import androidx.appcompat.app.AppCompatDelegate
+
+fun Context.localized(): Context {
+    val locales = AppCompatDelegate.getApplicationLocales()
+    if (locales.isEmpty) return this
+
+    val config = Configuration(resources.configuration)
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+        config.setLocales(locales.unwrap() as LocaleList)
+    } else {
+        @Suppress("DEPRECATION")
+        config.setLocale(locales.get(0))
+    }
+    return createConfigurationContext(config)
+}

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -204,6 +204,7 @@
     <string name="contributor_translation_gl">Galicische (gl) Übersetzung</string>
     <string name="contributor_translation_ru">Russische (ru) Übersetzung</string>
     <string name="contributor_translation_tr">Türkische (tr) Übersetzung</string>
+    <string name="contributor_language_selection">Manuelle Sprachauswahl und Weitergabe der Spracheinstellungen</string>
     <string name="contributor_fix_tts_ducking">Fix: Sprachansagen dämpfen jetzt die Hintergrundmusik, statt sie zu pausieren</string>
     <string name="contributor_fix_completion_counter">Korrektur: Der Abschlusszähler bleibt nicht mehr hängen und die Abschlussansage wird nicht mehr abgeschnitten, wenn der Bildschirm gesperrt wird</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -209,6 +209,16 @@
 
     <!-- Settings -->
     <string name="settings_title">Einstellungen</string>
+    <string name="settings_language">Sprache</string>
+    <string name="language_system_default">Systemstandard</string>
+    <string name="language_en">Englisch (English)</string>
+    <string name="language_de">Deutsch</string>
+    <string name="language_es">Spanisch (Español)</string>
+    <string name="language_fr">Französisch (Français)</string>
+    <string name="language_gl">Galicisch (Galego)</string>
+    <string name="language_pt_br">Portugiesisch (Português)</string>
+    <string name="language_ru">Russisch (Русский)</string>
+    <string name="language_tr">Türkisch (Türkçe)</string>
     <string name="settings_tts_enabled">Sprachansagen</string>
     <string name="settings_treadmill_mode">Laufband-Modus (deaktiviert GPS)</string>
     <string name="settings_gps_enabled">GPS-Tracking</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -207,6 +207,7 @@
     <string name="contributor_translation_gl">Traducción al Gallego (gl)</string>
     <string name="contributor_translation_ru">Traducción al Ruso (ru)</string>
     <string name="contributor_translation_tr">Traducción al turco (tr)</string>
+    <string name="contributor_language_selection">Selección manual de idioma y propagación de la configuración regional</string>
     <string name="contributor_fix_tts_ducking">Corrección: los anuncios de voz ahora atenúan la música de fondo en lugar de pausarla</string>
     <string name="contributor_fix_completion_counter">Corrección: el contador de finalización ya no se congela y el anuncio de finalización ya no se corta cuando la pantalla se bloquea</string>
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -212,6 +212,16 @@
 
     <!-- Settings -->
     <string name="settings_title">Configuración</string>
+    <string name="settings_language">Idioma</string>
+    <string name="language_system_default">Predeterminado del sistema</string>
+    <string name="language_en">Inglés (English)</string>
+    <string name="language_de">Alemán (Deutsch)</string>
+    <string name="language_es">Español</string>
+    <string name="language_fr">Francés (Français)</string>
+    <string name="language_gl">Gallego (Galego)</string>
+    <string name="language_pt_br">Portugués (Português)</string>
+    <string name="language_ru">Ruso (Русский)</string>
+    <string name="language_tr">Turco (Türkçe)</string>
     <string name="settings_tts_enabled">Indicaciones por voz</string>
     <string name="settings_treadmill_mode">Modo cinta de correr (desactiva GPS)</string>
     <string name="settings_gps_enabled">Seguimiento con GPS</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -212,6 +212,16 @@
 
     <!-- Settings -->
     <string name="settings_title">Paramètres</string>
+    <string name="settings_language">Langue</string>
+    <string name="language_system_default">Par défaut</string>
+    <string name="language_en">Anglais (English)</string>
+    <string name="language_de">Allemand (Deutsch)</string>
+    <string name="language_es">Espagnol (Español)</string>
+    <string name="language_fr">Français</string>
+    <string name="language_gl">Galicien (Galego)</string>
+    <string name="language_pt_br">Portugais (Português)</string>
+    <string name="language_ru">Russe (Русский)</string>
+    <string name="language_tr">Turc (Türkçe)</string>
     <string name="settings_tts_enabled">Annonces vocales</string>
     <string name="settings_treadmill_mode">Mode tapis de course (désactive le GPS)</string>
     <string name="settings_gps_enabled">Suivi GPS</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -207,6 +207,7 @@
     <string name="contributor_translation_gl">Traduction en galicien (gl)</string>
     <string name="contributor_translation_ru">Traduction en russe (ru)</string>
     <string name="contributor_translation_tr">Traduction en turc (tr)</string>
+    <string name="contributor_language_selection">Sélection manuelle de la langue et propagation des paramètres régionaux</string>
     <string name="contributor_fix_tts_ducking">Correction : les annonces vocales atténuent désormais la musique de fond au lieu de la mettre en pause</string>
     <string name="contributor_fix_completion_counter">Correction : le compteur de fin ne se fige plus et l\'annonce de fin n\'est plus coupée lorsque l\'écran se verrouille</string>
 

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -212,6 +212,16 @@
 
     <!-- Settings -->
     <string name="settings_title">Axustes</string>
+    <string name="settings_language">Idioma</string>
+    <string name="language_system_default">Predeterminado do sistema</string>
+    <string name="language_en">Inglés (English)</string>
+    <string name="language_de">Alemán (Deutsch)</string>
+    <string name="language_es">Español (Español)</string>
+    <string name="language_fr">Francés (Français)</string>
+    <string name="language_gl">Galego</string>
+    <string name="language_pt_br">Portugués (Português)</string>
+    <string name="language_ru">Ruso (Русский)</string>
+    <string name="language_tr">Turco (Türkçe)</string>
     <string name="settings_tts_enabled">Anuncios por voz</string>
     <string name="settings_treadmill_mode">Modo cinta de correr (desactiva GPS)</string>
     <string name="settings_gps_enabled">Gravar con GPS</string>

--- a/app/src/main/res/values-gl/strings.xml
+++ b/app/src/main/res/values-gl/strings.xml
@@ -207,6 +207,7 @@
     <string name="contributor_translation_gl">Tradución ao galego (gl)</string>
     <string name="contributor_translation_ru">Tradución ao ruso (ru)</string>
     <string name="contributor_translation_tr">Tradución ao turco (tr)</string>
+    <string name="contributor_language_selection">Selección manual do idioma e propagación da configuración rexional</string>
     <string name="contributor_fix_tts_ducking">Corrección: os avisos de voz agora atenúan a música de fondo en vez de pausala</string>
     <string name="contributor_fix_completion_counter">Corrección: o contador de finalización xa non se conxela e o anuncio de finalización xa non se corta cando a pantalla se bloquea</string>
 

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -212,6 +212,16 @@
 
     <!-- Settings -->
     <string name="settings_title">Configurações</string>
+    <string name="settings_language">Idioma</string>
+    <string name="language_system_default">Padrão do sistema</string>
+    <string name="language_en">Inglês (English)</string>
+    <string name="language_de">Alemão (Deutsch)</string>
+    <string name="language_es">Espanhol (Español)</string>
+    <string name="language_fr">Francês (Français)</string>
+    <string name="language_gl">Galego (Galego)</string>
+    <string name="language_pt_br">Português (Brasil)</string>
+    <string name="language_ru">Russo (Русский)</string>
+    <string name="language_tr">Turco (Türkçe)</string>
     <string name="settings_tts_enabled">Avisos de voz</string>
     <string name="settings_treadmill_mode">Modo esteira (desativa o GPS)</string>
     <string name="settings_gps_enabled">Rastreamento por GPS</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -207,6 +207,7 @@
     <string name="contributor_translation_gl">Tradução para o galego (gl)</string>
     <string name="contributor_translation_ru">Tradução para o russo (ru)</string>
     <string name="contributor_translation_tr">Tradução para o turco (tr)</string>
+    <string name="contributor_language_selection">Seleção manual de idioma e propagação da localidade</string>
     <string name="contributor_fix_tts_ducking">Correção: os avisos de voz agora reduzem o volume da música de fundo em vez de pausá-la</string>
     <string name="contributor_fix_completion_counter">Correção: o contador de conclusão não trava mais e o anúncio de conclusão não é mais cortado quando a tela é bloqueada</string>
 

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -215,6 +215,16 @@
 
     <!-- Settings -->
     <string name="settings_title">Настройки</string>
+    <string name="settings_language">Язык</string>
+    <string name="language_system_default">Системный по умолчанию</string>
+    <string name="language_en">Английский (English)</string>
+    <string name="language_de">Немецкий (Deutsch)</string>
+    <string name="language_es">Испанский (Español)</string>
+    <string name="language_fr">Французский (Français)</string>
+    <string name="language_gl">Галисийский (Galego)</string>
+    <string name="language_pt_br">Португальский (Português)</string>
+    <string name="language_ru">Русский</string>
+    <string name="language_tr">Турецкий (Türkçe)</string>
     <string name="settings_tts_enabled">Голосовые уведомления</string>
     <string name="settings_treadmill_mode">Режим беговой дорожки (отключает GPS)</string>
     <string name="settings_gps_enabled">GPS-отслеживание</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -210,6 +210,7 @@
     <string name="contributor_translation_gl">Перевод на галисийский (gl)</string>
     <string name="contributor_translation_ru">Перевод на русский (ru)</string>
     <string name="contributor_translation_tr">Перевод на турецкий (tr)</string>
+    <string name="contributor_language_selection">Ручной выбор языка и передача языковых настроек</string>
     <string name="contributor_fix_tts_ducking">Исправление: голосовые уведомления теперь приглушают фоновое воспроизведения музыки вместо установки её на паузу</string>
     <string name="contributor_fix_completion_counter">Исправление: счётчик завершения больше не зависает, и объявление о завершении больше не обрывается при блокировке экрана</string>
 

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -214,6 +214,16 @@
 
     <!-- Settings -->
     <string name="settings_title">Ayarlar</string>
+    <string name="settings_language">Dil</string>
+    <string name="language_system_default">Sistem varsayılanı</string>
+    <string name="language_en">İngilizce (English)</string>
+    <string name="language_de">Almanca (Deutsch)</string>
+    <string name="language_es">İspanyolca (Español)</string>
+    <string name="language_fr">Fransızca (Français)</string>
+    <string name="language_gl">Galiçyaca (Galego)</string>
+    <string name="language_pt_br">Brezilya Portekizcesi (Português)</string>
+    <string name="language_ru">Rusça (Русский)</string>
+    <string name="language_tr">Türkçe</string>
     <string name="settings_tts_enabled">Sesli yönlendirmeler</string>
     <string name="settings_treadmill_mode">Koşu bandı modu (GPS\'i kapatır)</string>
     <string name="settings_gps_enabled">GPS takibi</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -209,6 +209,7 @@
     <string name="contributor_translation_gl">Galiçyaca (gl) çeviri</string>
     <string name="contributor_translation_ru">Rusça (ru) çeviri</string>
     <string name="contributor_translation_tr">Türkçe (tr) çeviri</string>
+    <string name="contributor_language_selection">Manuel dil seçimi ve yerel ayarların aktarımı</string>
     <string name="contributor_fix_tts_ducking">Düzeltme: TTS seslendirmeleri artık arka plan müziğini duraklatmak yerine sesini kısıyor</string>
     <string name="contributor_fix_completion_counter">Düzeltme: Tamamlama sayacı artık ekran kilitlendiğinde donmuyor ve tamamlama anonsu kesilmiyor</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -212,6 +212,16 @@
 
     <!-- Settings -->
     <string name="settings_title">Settings</string>
+    <string name="settings_language">Language</string>
+    <string name="language_system_default">System default</string>
+    <string name="language_en">English</string>
+    <string name="language_de">Deutsch</string>
+    <string name="language_es">Español</string>
+    <string name="language_fr">Français</string>
+    <string name="language_gl">Galego</string>
+    <string name="language_pt_br">Português (Brasil)</string>
+    <string name="language_ru">Русский</string>
+    <string name="language_tr">Türkçe</string>
     <string name="settings_tts_enabled">Voice announcements</string>
     <string name="settings_treadmill_mode">Treadmill mode (disables GPS)</string>
     <string name="settings_gps_enabled">GPS tracking</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -207,6 +207,7 @@
     <string name="contributor_translation_gl">Galician (gl) translation</string>
     <string name="contributor_translation_ru">Russian (ru) translation</string>
     <string name="contributor_translation_tr">Turkish (tr) translation</string>
+    <string name="contributor_language_selection">Manual language selection and locale propagation</string>
     <string name="contributor_fix_tts_ducking">Fix: TTS announcements now duck background music instead of pausing it</string>
     <string name="contributor_fix_completion_counter">Fix: completion counter no longer freezes and the completion announcement no longer gets cut off when the screen locks</string>
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.C2K" parent="android:Theme.Material.Light.NoActionBar">
+    <style name="Theme.C2K" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="android:windowBackground">@color/splash_background</item>
     </style>
 </resources>

--- a/app/src/main/res/xml/locales_config.xml
+++ b/app/src/main/res/xml/locales_config.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale-config xmlns:android="http://schemas.android.com/apk/res/android">
+   <locale android:name="en"/>
+   <locale android:name="de"/>
+   <locale android:name="es"/>
+   <locale android:name="fr"/>
+   <locale android:name="gl"/>
+   <locale android:name="pt-BR"/>
+   <locale android:name="ru"/>
+   <locale android:name="tr"/>
+</locale-config>

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,6 @@ android.useAndroidX=true
 android.experimental.art.profile.emit=false
 android.suppressUnsupportedCompileSdk=36
 kotlin.code.style=official
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,3 @@ android.useAndroidX=true
 android.experimental.art.profile.emit=false
 android.suppressUnsupportedCompileSdk=36
 kotlin.code.style=official
-
-# Enabled parallel sync for Gradle 9.4+
-org.gradle.tooling.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.8.2"
+appcompat = "1.8.0"
 kotlin = "2.1.20"
 ksp = "2.1.20-1.0.31"
 composeBom = "2024.12.01"
@@ -20,6 +21,7 @@ compose-material-icons-extended  = { group = "androidx.compose.material",  name 
 compose-ui-test-junit4           = { group = "androidx.compose.ui",        name = "ui-test-junit4" }
 compose-ui-test-manifest         = { group = "androidx.compose.ui",        name = "ui-test-manifest" }
 activity-compose                 = { group = "androidx.activity",           name = "activity-compose",               version.ref = "activityCompose" }
+appcompat                        = { group = "androidx.appcompat",          name = "appcompat",                      version.ref = "appcompat" }
 
 lifecycle-viewmodel-compose      = { group = "androidx.lifecycle",         name = "lifecycle-viewmodel-compose",    version.ref = "lifecycle" }
 lifecycle-runtime-compose        = { group = "androidx.lifecycle",         name = "lifecycle-runtime-compose",      version.ref = "lifecycle" }


### PR DESCRIPTION
### Motivation
Hi! I downloaded the app from Google Play today to use it, but since my device system language is set to German, the app defaulted to German and I couldn't change it. Since I didn't want to change my whole system language just for one app, I decided to implement a manual language selection setting.

### Summary
Added a manual language selection option in the Settings menu so users can choose their app language manually instead of being forced to use the default system language.

### Note
I am a 2nd year Computer Science student, so the code might not be 100% perfect. Feedback are very welcome :)

### Testing
- Tested on my device (Pixel 10 Pro).
- Manually switched languages and verified the UI updates works.