### PR TITLE
docs: update display name for Unibilens

### DIFF
--- a/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/contributors/ContributorsScreen.kt
+++ b/app/src/main/kotlin/com/hackerapps/c2k/ui/screen/contributors/ContributorsScreen.kt
@@ -62,7 +62,7 @@ private val contributors = listOf(
         contributionRes = listOf(R.string.contributor_translation_tr)
     ),
     Contributor(
-        name = "Unibilens",
+        name = "Hamza Bilen",
         github = "Unibilens",
         contributionRes = listOf(R.string.contributor_language_selection)
     )


### PR DESCRIPTION
@AnalogGhost Thank you so much for adding me to the contributors list! This was actually my very first contribution to an external open-source project, so seeing myself in the credits really means a lot to me.

I realized that because I hadn't set my name on my GitHub profile earlier, my username `Unibilens` was used for name too. I've now added my name to my GitHub profile and updated it here in the code as well :)